### PR TITLE
Changed the WAVEDIG_VOLT_WF PV documentation

### DIFF
--- a/docs/source/databases.rst
+++ b/docs/source/databases.rst
@@ -411,7 +411,7 @@ These records are defined in the following files:
       buffers into the waveform records. Note that the driver always reads device when
       acquisition stops, so for quick acquisitions this record can be Passive. To see
       partial data during long acquisitions this record can be periodically processed.
-  * - $(P)VoltWF$(N)
+  * - $(P)WaveDigVoltWF$(N)
     - waveform
     - asynFloat64Array
     - WAVEDIG_VOLT_WF


### PR DESCRIPTION
The documentation lists the WAVEDIG_VOLT_WF PV as ``$(P)VoltWF$(N)``, but according to the [template file](https://github.com/epics-modules/LabJack/blob/master/LabJackApp/Db/LabJack_waveformDigN.template), the PV should be ``$(P)WaveDigVoltWF$(N)``. This PR changes the documentation to fix that bug.